### PR TITLE
Fix for GetBrightness(), isDark(), isLight()

### DIFF
--- a/TinyColor.livecodescript
+++ b/TinyColor.livecodescript
@@ -1,4 +1,13 @@
-script "tinyColor"
+# fix for RBG values which need to be passed as RGB (r, b, g), instead of "r,g,b" -- SK
+function colorForTiny pColor
+    if comma is in pColor then 
+        return "RGB (" & pColor & ")"
+    else
+        return pColor
+    end if
+end colorForTiny
+###################################################################
+
 # TinyColor v1.0.0b
 # Fast, small color manipulation and conversion for LiveCode.
 
@@ -89,11 +98,11 @@ end getSystemAppearance
 
 #### on tinyColor.prototype ####
 function isDark pRGB
-    return getBrightness() < 128
+    return getBrightness(pRGB) < 128
 end isDark
 
-function isLight
-    return not isDark()
+function isLight pRGB
+    return not isDark(pRGB)
 end isLight
 
 function isValid
@@ -116,7 +125,8 @@ function getBrightness pRGB
     // http://www.w3.org/TR/AERT#color-contrast
     local tRGB
     put _fixRGB(pRGB) into tRGB
-    return (tRGB["r"]* 299 + tRGB["g"]* 587 + tRGB["b"]* 114) / 1000
+    split tRGB by comma
+    return ((tRGB[1]* 299) + (tRGB[2]* 587) + (tRGB[3]* 114)) / 1000
 end getBrightness
 
 function getLuminance pRGB
@@ -432,7 +442,6 @@ function inputToRGB pColor
     // Input is liveCode RGB
     if the first char of pColor is a number and the number of items in pColor is 3 then
         put replaceText(pColor, space, empty) into rgb
-        replace space with empty in pColor
         split rgb by comma
         put rgb[1] into tResult["r"]
         put rgb[2] into tResult["g"]

--- a/TinyColor.livecodescript
+++ b/TinyColor.livecodescript
@@ -429,6 +429,18 @@ function inputToRGB pColor
         put true into tResult["ok"]
     end if
     
+    // Input is liveCode RGB
+    if the first char of pColor is a number and the number of items in pColor is 3 then
+        put replaceText(pColor, space, empty) into rgb
+        replace space with empty in pColor
+        split rgb by comma
+        put rgb[1] into tResult["r"]
+        put rgb[2] into tResult["g"]
+        put rgb[3] into tResult["b"]
+        put "rgb" into tResult["format"]
+        put true into tResult["ok"]
+    end if
+    
     if tResult["format"]is empty and typeof(pColor) is "string" then put stringInputToObject(pColor) into pColor
     
     if typeof(pColor) is "object" then

--- a/TinyColor.livecodescript
+++ b/TinyColor.livecodescript
@@ -1,12 +1,4 @@
-# fix for RBG values which need to be passed as RGB (r, b, g), instead of "r,g,b" -- SK
-function colorForTiny pColor
-    if comma is in pColor then 
-        return "RGB (" & pColor & ")"
-    else
-        return pColor
-    end if
-end colorForTiny
-###################################################################
+script "tinyColor"
 
 # TinyColor v1.0.0b
 # Fast, small color manipulation and conversion for LiveCode.


### PR DESCRIPTION
GetBrightness() incorrectly tries to process a an RGB text triplet as an array.
GetBrightness can take a triplet as a parameter - if empty uses sColor's RBG data
isDark() takes a parameter, but this is not passed to GetBrightness(), therefore isDark always returns the result for sColor, regardless of the parameter passed.
isLight() has no parameter to pass.

This fix splits the RBG triplet into an appropriate array in GetBrightness(). isDark() and isLight() adjusted to take an RGB parameter - if the param is empty then sColor's data is used.